### PR TITLE
refresh vc status before checking

### DIFF
--- a/ibuffer-vc.el
+++ b/ibuffer-vc.el
@@ -165,6 +165,7 @@ If the file is not under version control, nil is returned instead."
 
 (defun ibuffer-vc--state (file)
   "Return the `vc-state' for FILE, or nil if unregistered."
+  (vc-refresh-state)
   (ignore-errors (vc-state file)))
 
 (defun ibuffer-vc--status-string ()


### PR DESCRIPTION
Refresh the VC status before check it to avoid committed files are still tagged as `edited`.