### PR TITLE
Follow symlinks also when querying special buffers (like Dired)

### DIFF
--- a/ibuffer-vc.el
+++ b/ibuffer-vc.el
@@ -117,9 +117,8 @@ This option can be used to exclude certain files from the grouping mechanism."
   "Return a cons cell (backend-name . root-dir) for BUF.
 If the file is not under version control, nil is returned instead."
   (let ((file-name (with-current-buffer buf
-                     (or (when buffer-file-name
-                           (file-truename buffer-file-name))
-                         default-directory))))
+                     (file-truename (or buffer-file-name
+					default-directory)))))
     (when (ibuffer-vc--include-file-p file-name)
       (let ((backend (ibuffer-vc--deduce-backend file-name)))
         (when backend


### PR DESCRIPTION
Otherwise, if you have, say, a symlink from ~/symlinked_repo/ to
~/true_path_to_repo/, and then:

1. Open `~/symlinked_repo/` in Dired
2. Open `~/symlinked_repo/a_file_under_vc`
3. Run `M-x` `ibuffer-vc-set-filter-groups-by-vc-root`

the Dired buffer and the file buffer will be in two different
groups. (You will get something like the following:

```
[ Git:~/symlinked_repo/ ]
  %  symlinked_repo           $size Dired by name    ~/symlinked_repo
[ Git:~/true_path_to_repo/ ]
     a_file_under_vc          $size $mode    ~/symlinked_repo/a_file_under_vc
```

rather than:

```
[ Git:~/true_path_to_repo/ ]
  %  symlinked_repo           $size Dired by name    ~/symlinked_repo
     a_file_under_vc          $size $mode    ~/symlinked_repo/a_file_under_vc
```

The fact that the Filename column displays the symlinked path rather
than the "true" path is obviously independent of ibuffer-vc.)

The issue also occurs with Magit buffers, ansi-term buffers etc.


PS I love ibuffer-vc and couldn't imagine life without it! :)