### PR TITLE
Read vc-root from the minibuffer as a lisp object not a string

### DIFF
--- a/ibuffer-vc.el
+++ b/ibuffer-vc.el
@@ -137,7 +137,7 @@ If the file is not under version control, nil is returned instead."
 (define-ibuffer-filter vc-root
     "Toggle current view to buffers with vc root dir QUALIFIER."
   (:description "vc root dir"
-                :reader (read-from-minibuffer "Filter by vc root dir (regexp): "))
+                :reader (read-from-minibuffer "Filter by vc root dir: " nil nil t))
   (ibuffer-awhen (ibuffer-vc-root buf)
     (equal qualifier it)))
 


### PR DESCRIPTION
This is mostly an academic question, since manually specifying filters
with `ibuffer-filter-by-vc-root`, of the form

```
(Git . "~/path/")
```

is rather cumbersome, but it is useful for debugging purposes.

As far as I'm aware, if the filtering object is read from the minibuffer as a string rather than a lisp object, then there is no user-input that will produce a valid filter, in this case.

