### PR TITLE
Replace use of `ibuffer-awhen` with `when-let`.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,6 @@ jobs:
     strategy:
       matrix:
         emacs_version:
-          - 24.1
-          - 24.5
           - 25.1
           - 25.3
           - 26.1

--- a/ibuffer-vc.el
+++ b/ibuffer-vc.el
@@ -146,7 +146,7 @@ If the file is not under version control, nil is returned instead."
     "Toggle current view to buffers with vc root dir QUALIFIER."
   (:description "vc root dir"
                 :reader (ibuffer-vc-read-filter))
-  (ibuffer-awhen (ibuffer-vc-root buf)
+  (when-let ((it (ibuffer-vc-root buf)))
     (equal qualifier it)))
 
 ;;;###autoload

--- a/ibuffer-vc.el
+++ b/ibuffer-vc.el
@@ -4,7 +4,7 @@
 ;;
 ;; Author: Steve Purcell <steve@sanityinc.com>
 ;; Keywords: convenience
-;; Package-Requires: ((emacs "24.1") (cl-lib "0.2"))
+;; Package-Requires: ((emacs "25.1"))
 ;; URL: https://github.com/purcell/ibuffer-vc
 ;; Version: 0
 ;;


### PR DESCRIPTION
In emacs 29.1 (commit 3ef18c7a21), this function is marked obsolete and generates compiler warnings. I don't know exactly why that was done, but at least fixing it is pretty easy.