### PR TITLE
Prevent byte-compiler warning when vc-darcs is not installed

### DIFF
--- a/ibuffer-vc.el
+++ b/ibuffer-vc.el
@@ -150,7 +150,9 @@ If the file is not under version control, nil is returned instead."
                (root-dir
                 (cond
                  ((fboundp root-fn-name) (funcall root-fn-name file-name)) ; git, svn, hg, bzr (at least)
-                 ((memq backend '(darcs DARCS)) (vc-darcs-find-root file-name))
+                 ((and (fboundp 'vc-darcs-find-root)                       ; vc-darcs is an external package
+                       (memq backend '(darcs DARCS)))
+                  (vc-darcs-find-root file-name))
                  ((memq backend '(cvs CVS)) (vc-find-root file-name "CVS"))
                  ((memq backend '(rcs RCS)) (or (vc-find-root file-name "RCS")
                                                 (concat file-name ",v")))


### PR DESCRIPTION
This change prevents a byte-compiler warning if [vc-darcs](https://github.com/velkyel/vc-darcs) is not installed.

The error message generated by the `ibuffer-vc-root` should probably be updated as well when this is the case, but I did not add the extra logic for that.

Also, it might be of interest to add support for other VC backend (eg. [vc-fossil](https://github.com/venks1/emacs-fossil) and perhaps others that may exist) but I did not do that either.  I could if there's interest.